### PR TITLE
Update compose-rs to 0.0.4 and use new compose logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 clap = { version = "4.3", features = ["derive"] }
 docker-api = {version = "0.14.0", features = ["par-compress"] }
 tokio = {version = "1.32.0", features = ["full"] }
-compose-rs = "0.0.3"
+compose-rs = "0.0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,26 +120,13 @@ fn start_from_compose(_compose_file: &str, container_exists: bool) -> Result<(),
 
     if container_exists {
         // Use 'start' command for existing containers to preserve them
-        let output = Command::new("docker")
-            .arg("compose")
-            .arg("-f")
-            .arg(_compose_file)
-            .arg("start")
-            .output()
-            .map_err(|e| format!("Failed to execute docker compose start: {}", e))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("Docker compose start failed: {}", stderr));
+        let compose = Compose::builder()
+            .path(_compose_file)
+            .build()
+            .map_err(|e| format!("Failed to build compose: {}", e));
+        if let Err(e) = compose?.start().exec() {
+            return Err(format!("Failed to start container: {}", e));
         }
-
-        // TODO: Wait till PR gets merged into repo
-        // let compose = Compose::builder()
-        //     .path(_compose_file)
-        //     .build()
-        //     .map_err(|e| format!("Failed to build compose: {}", e));
-        // if let Err(e) = compose?.start().exec() {
-        //     return Err(format!("Failed to start container: {}", e));
-        // }
         println!("Existing container started successfully");
     } else {
         // Use 'up' command for new containers


### PR DESCRIPTION
## Summary
Updates compose-rs to version 0.0.4 and migrates the `start_from_compose` function to use the compose-rs library instead of manually invoking docker compose commands.

## Changes
- Updated compose-rs dependency from 0.0.3 to 0.0.4 in `Cargo.toml`
- Replaced manual `docker compose start` command execution with compose-rs library's `Compose::builder().path().build().start().exec()` pattern in the `start_from_compose` function

_This PR was generated with [Warp](https://www.warp.dev/)._
